### PR TITLE
Updated backup.py to support mistune 1.0 and 2.0.

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -165,8 +165,13 @@ def make_zip_file_path(*components):
         raise ValueError("path is empty")
     return "/".join(components)
 
+# Fallback to mistune 1.0 renderer if mistune 2.0 is not installed
+try:
+    mistuneRenderer = mistune.HTMLRenderer
+except AttributeError:
+    mistuneRenderer = mistune.Renderer
 # Custom mistune.Renderer that stores a list of all links encountered.
-class LinkExtractionRenderer(mistune.Renderer):
+class LinkExtractionRenderer(mistuneRenderer):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.links = []
@@ -179,7 +184,7 @@ class LinkExtractionRenderer(mistune.Renderer):
         self.links.append(src)
         return super().image(src, title, alt_text)
 
-    def link(self, link, title, content):
+    def link(self, link, title, content=None):
         self.links.append(link)
         return super().link(link, title, content)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+mistune >=2.0
+requests >=2.25


### PR DESCRIPTION
The current version of backup.py will fail  when using mistune 2.0. I've updated backup.py to support both mistune 1.0 and mistune 2.0. 

* Created requirements to make installation easier. 
* Added graceful fail-over for legacy users who do not have mistune 2.0 installed.