### PR TITLE
Fix datetime deprecation warning

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -26,6 +26,7 @@
 # complete when this program exits with a 0 return code.
 
 import datetime
+import email.utils
 import getopt
 import json
 import os.path
@@ -76,7 +77,7 @@ def rate_limit_reset(r):
 
 def response_datetime(r):
     dt = r.headers.get("date")
-    return datetime.datetime.strptime(dt, "%a, %d %b %Y %X %Z")
+    return email.utils.parsedate_to_datetime(dt)
 
 def get(sess, url, mediatype, params={}, **kwargs):
     # TODO: warn on 301 redirect? https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#follow-redirects

--- a/backup.py
+++ b/backup.py
@@ -72,7 +72,7 @@ def rate_limit_reset(r):
 
     # If x-ratelimit-remaining is set, assume x-ratelimit-reset is set.
     reset = r.headers["x-ratelimit-reset"]
-    return datetime.datetime.utcfromtimestamp(int(r.headers["x-ratelimit-reset"]))
+    return datetime.datetime.fromtimestamp(int(r.headers["x-ratelimit-reset"]), datetime.UTC).
 
 def response_datetime(r):
     dt = r.headers.get("date")

--- a/backup.py
+++ b/backup.py
@@ -72,7 +72,7 @@ def rate_limit_reset(r):
 
     # If x-ratelimit-remaining is set, assume x-ratelimit-reset is set.
     reset = r.headers["x-ratelimit-reset"]
-    return datetime.datetime.fromtimestamp(int(r.headers["x-ratelimit-reset"]), datetime.UTC).
+    return datetime.datetime.fromtimestamp(int(reset), datetime.UTC)
 
 def response_datetime(r):
     dt = r.headers.get("date")


### PR DESCRIPTION
Hello,

When I run the script, I get a deprecation warning. Furthermore, the variable `reset` appears to be unused and the value `r.headers["x-ratelimit-reset"]` seems to be queried twice. Both issues should be fixed by this PR.