### PR TITLE
Upload all images linked in issues

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -181,7 +181,7 @@ def link_is_wanted(url):
             # Inline image.
             return True
     if components.scheme == "https" and components.netloc == "github.com":
-        for prefix in (f"/{owner}/{repo}/files", "/user-attachments/files"):
+        for prefix in (f"/{owner}/{repo}/files", "/user-attachments/files", "/user-attachments/assets"):
             subpath = strip_url_path_prefix(components.path, prefix)
             if subpath is not None:
                 # File attachment.


### PR DESCRIPTION
Example:
First image in https://github.com/net4people/bbs/issues/561#issuecomment-3791531828 is `https://github.com/user-attachments/assets/6d3e8dfb-044a-41ad-a286-3cf7ac58892b`, but no in the SQLite database.
<img width="2560" height="1064" alt="Screenshot_2026-01-25_14-16-10" src="https://github.com/user-attachments/assets/bc0907df-6703-455a-97c0-c84eb9c6a52e" />
<img width="2180" height="1109" alt="Screenshot_2026-01-25_14-16-02" src="https://github.com/user-attachments/assets/c4f28b08-ec4b-4962-9b26-9d25d54c8f66" />
